### PR TITLE
Rename from "ctkjs" to "CTK-web"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# ctkjs
+# CTK-web
 A set of common web components for medical imaging, surgical navigation, and related purposes


### PR DESCRIPTION
Considering the library will contain more that javascript code, it
is sensible to name it "CTK-web".

Note also that based on npm recommendation, name of the package should
not have "js" or "node".

See: https://docs.npmjs.com/files/package.json
