### PR TITLE
package.json: Bump node minimum required version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/commontk/CTK-web.git"
   },
   "engines": {
-    "node": ">= 0.12",
+    "node": ">= v4.2.6",
     "npm": ">= 3.5"
   },
   "dependencies": {


### PR DESCRIPTION
To notify developer when using old verison of node, we set the node version
to match the default version used on circleci.
See https://circleci.com/docs/build-image-trusty/#nodejs

Fixes #5
